### PR TITLE
Allow 'class|descriptive title' as format in the control panel.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Changes
 1.2 (unreleased)
 ----------------
 
+- Allow ``class|descriptive title`` as format in the control panel.
+  When this format is used, we show the title in de portlet metadata
+  edit form.  A simple ``class`` is of course still supported.
+  [maurits]
+
 - Support the local portlet checkbox for ContentWellPortlets.
   [mauritsvanrees]
 

--- a/collective/portletmetadata/interfaces.py
+++ b/collective/portletmetadata/interfaces.py
@@ -13,7 +13,8 @@ class IMetadataSettings(Interface):
 
     css_classes = schema.Tuple(
         title=_(u"CSS Classes"),
-        description=_(u"Please enter the list of CSS classes, one per line"),
+        description=_(u"Please enter the list of CSS classes, one per line. "
+                      u"Format: class or class|descriptive title."),
         required=False,
         value_type=schema.TextLine(),
     )

--- a/collective/portletmetadata/vocabularies.py
+++ b/collective/portletmetadata/vocabularies.py
@@ -23,6 +23,11 @@ class CssClassesVocabulary(object):
 
         if settings.css_classes:
             for css_class in settings.css_classes:
-                result.append(SimpleTerm(css_class))
+                value = css_class
+                if '|' in css_class:
+                    value, title = css_class.split('|', 1)
+                else:
+                    value = title = css_class
+                result.append(SimpleTerm(value=value, title=title))
 
         return SimpleVocabulary(result)


### PR DESCRIPTION
When this format is used, we show the title in de portlet metadata
edit form.  A simple 'class' is of course still supported.
