### PR TITLE
Fix plone 5.0 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     install_requires=[
         'collective.monkeypatcher',
         'plone.portlets',
-        'plone.app.portlets>=4.0.0',
+        'plone.app.portlets>=3.0.0',
         'setuptools',
         'z3c.jbot',
         'z3c.unconfigure>=1.0.1',


### PR DESCRIPTION
This PR changes the minimum plone.app.portlets version to be 3.0.0. The 3.x series of plone.app.portlets is the version used by the 5.0.x buildout version pinning