### PR TITLE
Add field "Custom CSS classes".

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,16 @@
 Changes
 =======
 
-1.5.1 (unreleased)
+1.6.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add field "Custom CSS classes".
+  You can use this to freely add any (Bootstrap) classes, on top of the CSS classes made available in the control panel.
+  The new field and the existing control panel are now only available when you have the new "Portlets: Manage metadata" permission.
+  By default Manager and Site Administrator have this.
+  Previously only a Manager could access the control panel and make CSS classes available.
+  [maurits]
+
 
 
 1.5.0 (2022-09-08)

--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,9 @@ Out of the box the product provides the following features:
   even though child settings imply so.
 * Possibility for adding a CSS class for a portlet assignment. These are defined
   in the controlpanel (stored in registry).
+  Since version 1.6 you can add any CSS classes (for example from Bootstrap) in a portlet, without first defining it in the control panel.
+  This is restricted by a permission, so if you do not like this, you can take this permission away from some roles.
+  The field for choosing a pre-defined class is always available.
 * Possibility for excluding a portlet from being indexed by Google.
 
 

--- a/collective/portletmetadata/column.pt
+++ b/collective/portletmetadata/column.pt
@@ -6,7 +6,7 @@
     <div class="portletWrapper"
          tal:attributes="id string:portletwrapper-${portlet/hash};
                          data-portlethash portlet/hash">
-      <div tal:attributes="class portlet/settings/css_class | nothing">
+      <div tal:attributes="class string:${portlet/settings/css_class | nothing} ${portlet/settings/custom_css_classes | nothing}">
         <tal:block content="structure python:view.safe_render(portlet['renderer'])" />
       </div>
     </div>

--- a/collective/portletmetadata/configure.zcml
+++ b/collective/portletmetadata/configure.zcml
@@ -11,6 +11,11 @@
   <include package="plone.app.portlets" />
   <include package="z3c.jbot" file="meta.zcml" />
 
+  <permission
+      id="collective.portletmetadata.ManageMetadata"
+      title="Portlets: Manage metadata"
+      />
+
   <genericsetup:registerProfile
       name="default"
       title="collective.portletmetadata"
@@ -25,6 +30,14 @@
       directory="profiles/uninstall"
       description="Uninstalls the collective.portletmetadata add-on."
       provides="Products.GenericSetup.interfaces.EXTENSION"
+      />
+
+  <genericsetup:upgradeDepends
+      source="1"
+      destination="2"
+      title="Use new permission 'Portlets: Manage metadata'"
+      profile="collective.portletmetadata:default"
+      import_steps="rolemap controlpanel"
       />
 
   <!-- Core functionality -->
@@ -42,7 +55,7 @@
       name="portletmetadata-controlpanel"
       for="Products.CMFPlone.interfaces.IPloneSiteRoot"
       class=".controlpanel.ControlPanel"
-      permission="cmf.ManagePortal"
+      permission="collective.portletmetadata.ManageMetadata"
       layer=".interfaces.IBrowserLayer"
       />
 

--- a/collective/portletmetadata/interfaces.py
+++ b/collective/portletmetadata/interfaces.py
@@ -1,4 +1,5 @@
 from collective.portletmetadata import MessageFactory as _
+from plone.autoform import directives as form
 from zope import schema
 from zope.interface import Interface
 
@@ -34,6 +35,16 @@ class IPortletMetadata(Interface):
         vocabulary="collective.portletmetadata.CssClasses",
         required=False,
     )
+
+    custom_css_classes = schema.TextLine(
+        title=_(u"Custom CSS classes"),
+        description=_(
+            u"Freely add any (Bootstrap) classes, "
+            u"on top of the restricted classes above."
+        ),
+        required=False,
+    )
+    form.write_permission(custom_css_classes='collective.portletmetadata.ManageMetadata')
 
     exclude_search = schema.Bool(
         title=(u"Exclude from search"),

--- a/collective/portletmetadata/overrides/Products.ContentWellPortlets.browser.templates.renderer.pt
+++ b/collective/portletmetadata/overrides/Products.ContentWellPortlets.browser.templates.renderer.pt
@@ -14,7 +14,7 @@ This means we can get rid of the "manage portlets" link that comes along with al
 
     <div tal:attributes="id string:portletwrapper-${portlet/hash};
                          class string:portletWrapper kssattr-portlethash-${portlet/hash};">
-      <div tal:attributes="class portlet/settings/css_class | nothing">
+      <div tal:attributes="class string:${portlet/settings/css_class | nothing} ${portlet/settings/custom_css_classes | nothing}">
         <tal:block content="structure python:view.safe_render(portlet['renderer'])" />
       </div>
     </div>

--- a/collective/portletmetadata/profiles/default/controlpanel.xml
+++ b/collective/portletmetadata/profiles/default/controlpanel.xml
@@ -14,7 +14,7 @@
         url_expr="string:${portal_url}/@@portletmetadata-controlpanel"
         visible="True"
         i18n:attributes="title">
-            <permission>Manage portal</permission>
+            <permission>Portlets: Manage metadata</permission>
     </configlet>
 
 </object>

--- a/collective/portletmetadata/profiles/default/metadata.xml
+++ b/collective/portletmetadata/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>1</version>
+  <version>2</version>
   <dependencies>
   </dependencies>
 </metadata>

--- a/collective/portletmetadata/profiles/default/rolemap.xml
+++ b/collective/portletmetadata/profiles/default/rolemap.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rolemap>
+  <permissions>
+    <permission acquire="True"
+                name="Portlets: Manage metadata"
+    >
+      <role name="Manager" />
+      <role name="Site Administrator" />
+    </permission>
+  </permissions>
+</rolemap>

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(*pathnames):
     return open(os.path.join(os.path.dirname(__file__), *pathnames)).read()
 
 
-version = "1.5.1.dev0"
+version = "1.6.0.dev0"
 
 setup(
     name="collective.portletmetadata",
@@ -35,6 +35,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
     keywords="portlets metadata class",
     author="Bo Simonsen",
@@ -47,12 +48,12 @@ setup(
     zip_safe=False,
     install_requires=[
         "collective.monkeypatcher",
+        "plone.autoform",
         "plone.portlets",
         "plone.app.portlets>=3.0.0",
         "setuptools",
         "z3c.jbot",
         "z3c.unconfigure>=1.0.1",
-        # -*- Extra requirements: -*-
     ],
     entry_points="""
         # -*- Entry points: -*-


### PR DESCRIPTION
This implements my idea from issue #12, but it keeps the existing field without change, and only adds a field.

You can use this to freely add any (Bootstrap) classes, on top of the CSS classes made available in the control panel. The new field and the existing control panel are now only available when you have the new "Portlets: Manage metadata" permission. By default Manager and Site Administrator have this. Previously only a Manager could access the control panel and make CSS classes available.